### PR TITLE
feat(button): added fluid prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Input component @alinais ([#64](https://github.com/stardust-ui/react/pull/64))
 - Add Text `important` prop @mnajdova ([#120](https://github.com/stardust-ui/react/pull/120))
 - Add Avatar `alt` prop @mnajdova ([#124](https://github.com/stardust-ui/react/pull/124))
+- Add Button `fluid` prop @Bugaa92 ([#6](https://github.com/stardust-ui/react/pull/6))
 
 ### Documentation
 - Add accessibility section to each component @mnajdova ([#46](https://github.com/stardust-ui/react/pulls/46))

--- a/docs/src/examples/components/Button/Variations/ButtonExampleFluid.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleFluid.shorthand.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Button } from '@stardust-ui/react'
+
+const ButtonExampleFluid = () => <Button fluid content="Fits to Container" />
+
+export default ButtonExampleFluid

--- a/docs/src/examples/components/Button/Variations/ButtonExampleFluid.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleFluid.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Button } from '@stardust-ui/react'
+
+const ButtonExampleFluid = () => <Button fluid>Fits to Container</Button>
+
+export default ButtonExampleFluid

--- a/docs/src/examples/components/Button/Variations/index.tsx
+++ b/docs/src/examples/components/Button/Variations/index.tsx
@@ -5,6 +5,11 @@ import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 const Variations = () => (
   <ExampleSection title="Variations">
     <ComponentExample
+      title="Fluid"
+      description="A button can take the width of its container."
+      examplePath="components/Button/Variations/ButtonExampleFluid"
+    />
+    <ComponentExample
       title="Circular"
       description="A button can be circular."
       examplePath="components/Button/Variations/ButtonExampleCircular"

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,27 +1,43 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { ReactNode, CSSProperties } from 'react'
 
-import { UIComponent, childrenExist, customPropTypes } from '../../lib'
+import { UIComponent, childrenExist, customPropTypes, IRenderResultConfig } from '../../lib'
 import buttonRules from './buttonRules'
 import buttonVariables from './buttonVariables'
+
+export type ButtonType = 'primary' | 'secondary'
+
+export interface IButtonProps {
+  as?: string
+  children?: ReactNode
+  circular?: boolean
+  className?: string
+  content?: ReactNode
+  fluid?: boolean
+  style?: CSSProperties
+  type?: ButtonType
+}
 
 /**
  * A button.
  * @accessibility This is example usage of the accessibility tag.
  * This should be replaced with the actual description after the PR is merged
  */
-class Button extends UIComponent<any, any> {
-  static displayName = 'Button'
+class Button extends UIComponent<IButtonProps, any> {
+  public static displayName = 'Button'
 
-  static className = 'ui-button'
+  public static className = 'ui-button'
 
-  static rules = buttonRules
+  public static rules = buttonRules
 
-  static variables = buttonVariables
+  public static variables = buttonVariables
 
-  static propTypes = {
+  public static propTypes = {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
+
+    /** Primary content. */
+    children: PropTypes.node,
 
     /** A button can appear circular. */
     circular: PropTypes.bool,
@@ -32,18 +48,34 @@ class Button extends UIComponent<any, any> {
     /** Shorthand for primary content. */
     content: customPropTypes.contentShorthand,
 
+    /** A button can take the width of its container. */
+    fluid: PropTypes.bool,
+
     /** A button can be formatted to show different levels of emphasis. */
     type: PropTypes.oneOf(['primary', 'secondary']),
   }
 
-  static handledProps = ['as', 'circular', 'className', 'content', 'type']
+  public static handledProps = [
+    'as',
+    'children',
+    'circular',
+    'className',
+    'content',
+    'fluid',
+    'type',
+  ]
 
-  static defaultProps = {
+  public static defaultProps = {
     as: 'button',
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  public renderComponent({
+    ElementType,
+    classes,
+    rest,
+  }: IRenderResultConfig<IButtonProps>): ReactNode {
     const { children, content } = this.props
+
     return (
       <ElementType {...rest} className={classes.root}>
         {childrenExist(children) ? children : content}
@@ -51,4 +83,5 @@ class Button extends UIComponent<any, any> {
     )
   }
 }
+
 export default Button

--- a/src/components/Button/buttonRules.ts
+++ b/src/components/Button/buttonRules.ts
@@ -1,8 +1,13 @@
 import { pxToRem } from '../../lib'
 import { IButtonVariables } from './buttonVariables'
+import { IButtonProps } from './Button'
 
 export default {
-  root: ({ props, theme, variables }) => {
+  root: ({ props, variables }: { props: IButtonProps; variables: IButtonVariables }) => {
+    const { children, circular, content, fluid, type } = props
+    const primary = type === 'primary'
+    const secondary = type === 'secondary'
+
     const {
       backgroundColor,
       backgroundColorHover,
@@ -31,9 +36,11 @@ export default {
       ':hover': {
         backgroundColor: backgroundColorHover,
       },
-      ...(props.circular && { borderRadius: circularRadius, width: circularWidth }),
+      ...(circular && { borderRadius: circularRadius, width: circularWidth }),
 
-      ...(props.type === 'primary' && {
+      ...(fluid && { display: 'block', width: '100%' }),
+
+      ...(type === 'primary' && {
         color: typePrimaryColor,
         backgroundColor: typePrimaryBackgroundColor,
         borderColor: typePrimaryBorderColor,
@@ -42,7 +49,7 @@ export default {
         },
       }),
 
-      ...(props.type === 'secondary' && {
+      ...(type === 'secondary' && {
         color: typeSecondaryColor,
         backgroundColor: typeSecondaryBackgroundColor,
         borderColor: typeSecondaryBorderColor,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,7 +12,7 @@ export * from './factories'
 export { default as getClasses } from './getClasses'
 export { default as getElementType } from './getElementType'
 export { default as getUnhandledProps } from './getUnhandledProps'
-export { default as renderComponent } from './renderComponent'
+export { default as renderComponent, IRenderResultConfig } from './renderComponent'
 export {
   useKeyOnly,
   useKeyOrValueAndKey,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
#  Button (`fluid` prop)

This PR will introduce possibility to specify `fluid` buttons

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## fluid

`fluid` will allow a button to take the width of its container.

![fluid](https://user-images.githubusercontent.com/5442794/43145367-7d517308-8f5f-11e8-858a-675c63fddb22.PNG)


[The circular prop is one of many shapes.  Proposing shapes be grouped as enums under the `shape` prop.] 

```jsx
<Button fluid content="Fits to Container" />
```

```html
<button class="ui-button">Fits to Container</button>
```
