### PR TITLE
docs: improve example knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Documentation
+- Improve UX for "knobs" form on component examples @levithomason ([#20](https://github.com/stardust-ui/react/pull/20))
+
 <!--------------------------------[ v0.2.3 ]------------------------------- -->
 ## [v0.2.3](https://github.com/stardust-ui/react/tree/v0.2.3) (2018-07-24)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.2.2...v0.2.3)

--- a/docs/src/components/Knobs/Knobs.tsx
+++ b/docs/src/components/Knobs/Knobs.tsx
@@ -1,6 +1,7 @@
+import React from 'react'
 import { createComponent } from 'react-fela'
-import { pxToRem } from 'src/lib'
 
+import { pxToRem } from 'src/lib'
 import KnobsField from './KnobsField'
 import KnobsControl from './KnobsControl'
 import KnobsLabel from './KnobsLabel'
@@ -11,12 +12,26 @@ import KnobsScalar from './KnobsScalar'
 
 const Knobs: any = createComponent(
   () => ({
-    padding: pxToRem(10),
-    background: '#eee',
+    position: 'relative',
+    display: 'inline-block',
+    padding: `${pxToRem(5)} ${pxToRem(10)}`,
+    width: '50%',
+    minWidth: '20rem',
+    fontFamily: 'monospace',
+    fontSize: pxToRem(12),
+    fontWeight: 'bold',
+    lineHeight: '1.5',
+    background: 'whitesmoke',
+    color: '#777',
+    '::before': {
+      content: "'knobs = {'",
+    },
+    '::after': {
+      content: "'}'",
+    },
   }),
   'div',
 )
-
 Knobs.Field = KnobsField
 Knobs.Control = KnobsControl
 Knobs.Label = KnobsLabel

--- a/docs/src/components/Knobs/KnobsBoolean.tsx
+++ b/docs/src/components/Knobs/KnobsBoolean.tsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 
 import KnobsField from './KnobsField'
 import KnobsLabel from './KnobsLabel'
-import KnobsValue from './KnobsValue'
 import KnobsControl from './KnobsControl'
 
 class KnobsBoolean extends Component<any, any> {
@@ -28,8 +27,7 @@ class KnobsBoolean extends Component<any, any> {
         <KnobsControl>
           <input type="checkbox" defaultChecked={booleanValue} onChange={this.handleChange} />
         </KnobsControl>
-        <KnobsLabel>{name}</KnobsLabel>
-        <KnobsValue>{value}</KnobsValue>
+        <KnobsLabel value={value} name={name} />
       </KnobsField>
     )
   }

--- a/docs/src/components/Knobs/KnobsControl.tsx
+++ b/docs/src/components/Knobs/KnobsControl.tsx
@@ -3,7 +3,9 @@ import { pxToRem } from 'src/lib'
 
 const KnobsControl = createComponent(
   () => ({
-    padding: `0 ${pxToRem(10)}`,
+    marginRight: pxToRem(5),
+    verticalAlign: 'middle',
+    textAlign: 'center',
   }),
   'span',
 )

--- a/docs/src/components/Knobs/KnobsField.tsx
+++ b/docs/src/components/Knobs/KnobsField.tsx
@@ -2,8 +2,8 @@ import { createComponent } from 'react-fela'
 import { pxToRem } from 'src/lib'
 
 const KnobsField = createComponent(() => ({
-  padding: `${pxToRem(5)} 0`,
-  width: pxToRem(300),
+  display: 'grid',
+  gridTemplateColumns: `${pxToRem(60)} auto`,
 }))
 
 export default KnobsField

--- a/docs/src/components/Knobs/KnobsLabel.tsx
+++ b/docs/src/components/Knobs/KnobsLabel.tsx
@@ -1,10 +1,14 @@
-import { createComponent } from 'react-fela'
+import React from 'react'
 
-const KnobsLabel = createComponent(
-  () => ({
-    fontFamily: 'monospace',
-  }),
-  'label',
+interface IKnobsLabelProps {
+  name: string
+  value: string
+}
+
+const KnobsLabel: React.ComponentType<IKnobsLabelProps> = ({ name, value }) => (
+  <span>
+    {name}: {JSON.stringify(value, null, 2)},
+  </span>
 )
 
 export default KnobsLabel

--- a/docs/src/components/Knobs/KnobsScalar.tsx
+++ b/docs/src/components/Knobs/KnobsScalar.tsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 
 import KnobsField from './KnobsField'
 import KnobsLabel from './KnobsLabel'
-import KnobsValue from './KnobsValue'
+import KnobsControl from './KnobsControl'
 
 class KnobsScalar extends Component<any, any> {
   static propTypes = {
@@ -39,17 +39,18 @@ class KnobsScalar extends Component<any, any> {
 
     return (
       <KnobsField>
-        <KnobsLabel>{name}</KnobsLabel>
-        <KnobsValue>{value}</KnobsValue>
-        <br />
-        <input
-          type="range"
-          min="0"
-          max={this.defaultValue * 3}
-          step="1"
-          value={this.parseValue(value)}
-          onChange={this.handleChange}
-        />
+        <KnobsControl>
+          <input
+            type="range"
+            min="0"
+            max={this.defaultValue * 3}
+            step="1"
+            value={this.parseValue(value)}
+            onChange={this.handleChange}
+            style={{ width: '100%' }}
+          />
+        </KnobsControl>
+        <KnobsLabel name={name} value={value} />
       </KnobsField>
     )
   }

--- a/src/styles/debugRules.ts
+++ b/src/styles/debugRules.ts
@@ -31,7 +31,6 @@ export const debugArea = () => ({
 export const debugGap = ({ vertical }) => ({
   display: 'grid',
   background: '#ccc',
-  // border: '2px solid gray',
   '::before': {
     content: '"GAP"',
     ...(vertical


### PR DESCRIPTION
This PR updates the knobs experience for examples to make it more clear how the values relate to the example code.

# Before

![image](https://user-images.githubusercontent.com/5067638/43212843-e9f494a6-8fe9-11e8-976e-a73768fa95be.png)

# After

![image](https://user-images.githubusercontent.com/5067638/43212876-ffbe1780-8fe9-11e8-9688-44254726cc79.png)
