### PR TITLE
feat(icon): adding `xSpacing=['none'|'before'|'after'|'both']` prop to Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add Button `fluid` prop @Bugaa92 ([#6](https://github.com/stardust-ui/react/pull/6))
 - Add Icon `disabled` prop @Bugaa92 ([#12](https://github.com/stardust-ui/react/pull/12))
+- Add Icon `xSpacing` prop @Bugaa92 ([#22](https://github.com/stardust-ui/react/pull/22))
 
 <!--------------------------------[ v0.2.2 ]------------------------------- -->
 ## [v0.2.2](https://github.com/stardust-ui/react/tree/v0.2.2) (2018-07-24)

--- a/docs/src/examples/components/Icon/Variations/IconExampleSpace.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleSpace.shorthand.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Icon, Label } from '@stardust-ui/react'
+
+const IconExampleSpace = () => (
+  <div>
+    <Label content="Default" />
+    <Icon name="help" />
+    <Label content="None" />
+    <Icon xSpacing="none" name="help" />
+    <Label content="Before" />
+    <Icon xSpacing="before" name="help" />
+    <Label content="After" />
+    <Icon xSpacing="before" name="help" />
+    <Label content="Both" />
+    <Icon xSpacing="both" name="help" />
+    <Label content="End" />
+  </div>
+)
+
+export default IconExampleSpace

--- a/docs/src/examples/components/Icon/Variations/index.tsx
+++ b/docs/src/examples/components/Icon/Variations/index.tsx
@@ -5,6 +5,11 @@ import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 const Variations = () => (
   <ExampleSection title="Variations">
     <ComponentExample
+      title="Space"
+      description="An icon can have space before, after or on both sides. 'none' value removes the default space around the icon"
+      examplePath="components/Icon/Variations/IconExampleSpace"
+    />
+    <ComponentExample
       title="Size"
       description="An icon can vary in size."
       examplePath="components/Icon/Variations/IconExampleSize"

--- a/src/components/Avatar/avatarRules.ts
+++ b/src/components/Avatar/avatarRules.ts
@@ -1,4 +1,5 @@
 import { pxToRem } from '../../lib'
+import { PositionProperty } from '../../../node_modules/csstype'
 
 const getAvatarDimension = (size: number) => {
   return 12 + size * 4
@@ -93,6 +94,6 @@ export default {
   presenceIcon: () => ({
     margin: 'auto',
     bottom: pxToRem(2),
-    position: 'relative',
+    position: 'relative' as PositionProperty,
   }),
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,11 +1,46 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import PropTypes from 'prop-types'
 import { customPropTypes, UIComponent, SUI } from '../../lib'
 
 import iconRules from './iconRules'
 import iconVariables from './iconVariables'
 
-class Icon extends UIComponent<any, any> {
+export type IconColor =
+  | 'white'
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'olive'
+  | 'green'
+  | 'teal'
+  | 'blue'
+  | 'violet'
+  | 'purple'
+  | 'pink'
+  | 'brown'
+  | 'grey'
+  | 'black'
+
+export type IconSize = 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
+
+export type IconXSpacing = 'none' | 'before' | 'after' | 'both'
+
+export interface IconProps {
+  as?: string
+  bordered?: boolean
+  circular?: boolean
+  className?: string
+  color?: IconColor
+  disabled?: boolean
+  kind?: string
+  name?: string
+  size?: IconSize
+  xSpacing?: IconXSpacing
+  style?: CSSProperties
+  title?: string
+}
+
+class Icon extends UIComponent<IconProps, {}> {
   static className = 'ui-icon'
 
   static displayName = 'Icon'
@@ -54,6 +89,9 @@ class Icon extends UIComponent<any, any> {
 
     /** Size of the icon. */
     size: PropTypes.oneOf(['mini', 'tiny', 'small', 'large', 'big', 'huge', 'massive']),
+
+    /** Adds space to the before, after or on both sides of the icon, or removes the default space around the icon ('none' value) */
+    xSpacing: PropTypes.oneOf(['none', 'before', 'after', 'both']),
   }
 
   static handledProps = [
@@ -66,6 +104,7 @@ class Icon extends UIComponent<any, any> {
     'kind',
     'name',
     'size',
+    'xSpacing',
   ]
 
   static defaultProps = {

--- a/src/components/Icon/iconRules.ts
+++ b/src/components/Icon/iconRules.ts
@@ -1,5 +1,13 @@
 import fontAwesomeIcons from './fontAwesomeIconRules'
-import { disabledStyles } from '../../styles/customCSS'
+import { disabledStyle, fittedStyle } from '../../styles/customCSS'
+import { IconProps, IconXSpacing } from './Icon'
+import { IconVariables } from './iconVariables'
+import { CSSProperties } from '../../../node_modules/@types/react'
+
+interface IconRulesParams {
+  props: IconProps
+  variables: IconVariables
+}
 
 const sizes = new Map([
   ['mini', 0.4],
@@ -29,7 +37,20 @@ const getIcon = (kind, name) => {
 
 const getSize = size => `${sizes.get(size)}em` || '1em'
 
-const getBorderedStyles = (circular, borderColor, color) => ({
+const getXSpacingStyles = (xSpacing: IconXSpacing, horizontalSpace: string): CSSProperties => {
+  switch (xSpacing) {
+    case 'none':
+      return fittedStyle
+    case 'before':
+      return { ...fittedStyle, marginLeft: horizontalSpace }
+    case 'after':
+      return { ...fittedStyle, marginRight: horizontalSpace }
+    case 'both':
+      return { ...fittedStyle, margin: `0 ${horizontalSpace}` }
+  }
+}
+
+const getBorderedStyles = (circular, borderColor, color): CSSProperties => ({
   lineHeight: '1',
   padding: '0.5em 0',
   boxShadow: `0 0 0 0.1em ${borderColor || color || 'black'} inset`,
@@ -39,7 +60,10 @@ const getBorderedStyles = (circular, borderColor, color) => ({
 })
 
 const iconRules = {
-  root: ({ props: { color, disabled, kind, name, size, bordered, circular }, variables: v }) => {
+  root: ({
+    props: { color, disabled, kind, name, size, bordered, circular, xSpacing },
+    variables: v,
+  }: IconRulesParams) => {
     const { fontFamily, content } = getIcon(kind, name)
     const iconColor = color || v.color
 
@@ -48,7 +72,7 @@ const iconRules = {
       color: iconColor,
       display: 'inline-block',
       opacity: 1,
-      margin: '0 0.25em 0 0',
+      margin: v.margin,
       width: '1.18em',
       height: '1em',
       fontSize: getSize(size),
@@ -69,9 +93,11 @@ const iconRules = {
         background: '0 0',
       },
 
-      ...((bordered || circular) && getBorderedStyles(circular, v.borderColor, iconColor)),
+      ...(disabled && disabledStyle),
 
-      ...(disabled && disabledStyles),
+      ...getXSpacingStyles(xSpacing, v.horizontalSpace),
+
+      ...((bordered || circular) && getBorderedStyles(circular, v.borderColor, iconColor)),
     }
   },
 }

--- a/src/components/Icon/iconVariables.ts
+++ b/src/components/Icon/iconVariables.ts
@@ -1,4 +1,15 @@
-export default () => ({
-  color: 'black',
+import { pxToRem } from '../../lib'
+
+export interface IconVariables {
+  borderColor: string
+  color: string
+  horizontalSpace: string
+  margin: string
+}
+
+export default (): IconVariables => ({
   borderColor: undefined,
+  color: 'black',
+  horizontalSpace: pxToRem(10),
+  margin: '0 0.25em 0 0',
 })

--- a/src/styles/customCSS.ts
+++ b/src/styles/customCSS.ts
@@ -1,6 +1,22 @@
 import { CSSProperties } from 'react'
 
-export const disabledStyles: CSSProperties = {
+export const disabledStyle: CSSProperties = {
   opacity: 0.45,
   cursor: 'not-allowed',
+}
+
+export const fittedStyle: CSSProperties = {
+  margin: 0,
+  width: 'auto',
+}
+
+export const truncateStyle: CSSProperties = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
+
+export const overflowWrapStyle: CSSProperties = {
+  overflow: 'overlay',
+  overflowWrap: 'break-word',
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Icon

This PR will introduce possibility to specify `xSpacing=['none'|'before'|'after'|'both']` prop on an **Icon** component in order to adjust horizontal space around icons.


### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## `xSpacing`

An icon can achieve the following horizontal spacing:
- `xSpacing='none'`: no space to before or after the icon;
- `xSpacing='before'`: space before the icon;
- `xSpacing='after'`: space after the icon;
- `xSpacing='both'`: space before and afer the icon;

![screen shot 2018-07-30 at 16 32 13](https://user-images.githubusercontent.com/5442794/43403815-64b3e11c-9416-11e8-8e99-9bc10b715bc1.png)

```jsx
<div>
  <Icon xSpacing="none" name="help" />
  <Icon xSpacing="before" name="help" />
  <Icon xSpacing="after" name="help" />
  <Icon xSpacing="both" name="help" />
</div>
```
generates:
```html
<div>
  <i class="ui-icon"></i>
  <i class="ui-icon"></i>
  <i class="ui-icon"></i>
  <i class="ui-icon"></i>
</div>
```