### PR TITLE
fix(Input): changing the default styles for Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+
+- Changing the default styles for Input component @alinais ([#25](https://github.com/stardust-ui/react/pull/25))
+
 ### Features
 - Update styles for Menu underlined primary @miroslavstastny ([#20](https://github.com/stardust-ui/react/pull/20))
   
@@ -32,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.2.3...v0.2.4)
 
 ### Fixes
+
 - Replaced Header `subheader` with `description` and fixed it to render well-formed HTML @mnajdova ([#17](https://github.com/stardust-ui/react/pull/17))
 - Removed allowSyntheticDefaultImports from shared tsconfig but allow it on docs @aniknafs ([#46](https://github.com/stardust-ui/react/pull/46))
 

--- a/docs/src/examples/components/Input/Variations/index.tsx
+++ b/docs/src/examples/components/Input/Variations/index.tsx
@@ -6,7 +6,7 @@ const Variations = () => (
   <ExampleSection title="Variations">
     <ComponentExample
       title="Icon"
-      description="An input can have a search icon."
+      description="An input can have an icon."
       examplePath="components/Input/Variations/InputExampleIcon"
     />
   </ExampleSection>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,5 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
-import * as cx from 'classnames'
 import * as _ from 'lodash'
 
 import {
@@ -102,8 +101,8 @@ class Input extends UIComponent<any, any> {
     const { children, className, icon, input, type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
-    const inputClasses = cx(classes.input)
-    const iconClasses = cx(classes.icon)
+    const inputClasses = classes.input
+    const iconClasses = classes.icon
 
     // Render with children
     // ----------------------------------------
@@ -121,24 +120,6 @@ class Input extends UIComponent<any, any> {
       )
     }
 
-    if (this.computeIcon()) {
-      return (
-        <ElementType {...rest} className={classes.root} {...htmlInputProps}>
-          {createHTMLInput(input || type, {
-            defaultProps: htmlInputProps,
-            overrideProps: {
-              className: inputClasses,
-              ref: this.handleInputRef,
-            },
-          })}
-          {Icon.create(this.computeIcon(), {
-            defaultProps: { className: iconClasses },
-            overrideProps: predefinedProps => this.handleIconOverrides,
-          })}
-        </ElementType>
-      )
-    }
-
     return (
       <ElementType {...rest} className={classes.root} {...htmlInputProps}>
         {createHTMLInput(input || type, {
@@ -148,6 +129,11 @@ class Input extends UIComponent<any, any> {
             ref: this.handleInputRef,
           },
         })}
+        {this.computeIcon() &&
+          Icon.create(this.computeIcon(), {
+            defaultProps: { className: iconClasses },
+            overrideProps: predefinedProps => this.handleIconOverrides,
+          })}
       </ElementType>
     )
   }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -14,6 +14,7 @@ import {
 import inputRules from './inputRules'
 import inputVariables from './inputVariables'
 import Icon from '../Icon'
+import callable from '../../lib/callable'
 
 /**
  * An Input
@@ -54,10 +55,19 @@ class Input extends UIComponent<any, any> {
     type: 'text',
   }
 
+  inputRef: any
+
+  computeTabIndex = props => {
+    if (!_.isNil(props.tabIndex)) return props.tabIndex
+    if (props.onClick) return 0
+  }
+
   handleChildOverrides = (child, defaultProps) => ({
     ...defaultProps,
     ...child.props,
   })
+
+  handleInputRef = c => (this.inputRef = c)
 
   partitionProps = () => {
     const { type } = this.props
@@ -69,6 +79,7 @@ class Input extends UIComponent<any, any> {
       {
         ...htmlInputProps,
         type,
+        onClick: () => this.inputRef.focus(),
       },
       rest,
     ]
@@ -79,6 +90,12 @@ class Input extends UIComponent<any, any> {
 
     if (!_.isNil(icon)) return icon
     return null
+  }
+
+  handleIconOverrides = predefinedProps => {
+    return {
+      tabIndex: this.computeTabIndex,
+    }
   }
 
   renderComponent({ ElementType, classes, rest }) {
@@ -109,9 +126,15 @@ class Input extends UIComponent<any, any> {
         <ElementType {...rest} className={classes.root} {...htmlInputProps}>
           {createHTMLInput(input || type, {
             defaultProps: htmlInputProps,
-            overrideProps: { className: inputClasses },
+            overrideProps: {
+              className: inputClasses,
+              ref: this.handleInputRef,
+            },
           })}
-          <Icon name={this.computeIcon()} className={iconClasses} />
+          {Icon.create(this.computeIcon(), {
+            defaultProps: { className: iconClasses },
+            overrideProps: predefinedProps => this.handleIconOverrides,
+          })}
         </ElementType>
       )
     }
@@ -120,7 +143,10 @@ class Input extends UIComponent<any, any> {
       <ElementType {...rest} className={classes.root} {...htmlInputProps}>
         {createHTMLInput(input || type, {
           defaultProps: htmlInputProps,
-          overrideProps: { className: inputClasses },
+          overrideProps: {
+            className: inputClasses,
+            ref: this.handleInputRef,
+          },
         })}
       </ElementType>
     )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -78,7 +78,6 @@ class Input extends UIComponent<any, any> {
       {
         ...htmlInputProps,
         type,
-        onClick: () => this.inputRef.focus(),
       },
       rest,
     ]
@@ -93,6 +92,10 @@ class Input extends UIComponent<any, any> {
 
   handleIconOverrides = predefinedProps => {
     return {
+      onClick: e => {
+        this.inputRef.focus()
+        _.invoke(predefinedProps, 'onClick', e, this.props)
+      },
       tabIndex: this.computeTabIndex,
     }
   }
@@ -132,7 +135,7 @@ class Input extends UIComponent<any, any> {
         {this.computeIcon() &&
           Icon.create(this.computeIcon(), {
             defaultProps: { className: iconClasses },
-            overrideProps: predefinedProps => this.handleIconOverrides,
+            overrideProps: this.handleIconOverrides,
           })}
       </ElementType>
     )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -86,6 +86,7 @@ class Input extends UIComponent<any, any> {
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const inputClasses = cx(classes.input)
+    const iconClasses = cx(classes.icon)
 
     // Render with children
     // ----------------------------------------
@@ -110,7 +111,7 @@ class Input extends UIComponent<any, any> {
             defaultProps: htmlInputProps,
             overrideProps: { className: inputClasses },
           })}
-          <Icon name={this.computeIcon()} />
+          <Icon name={this.computeIcon()} className={iconClasses} />
         </ElementType>
       )
     }

--- a/src/components/Input/inputRules.ts
+++ b/src/components/Input/inputRules.ts
@@ -9,6 +9,11 @@ const inputRules = {
       borderRadius: variables.borderRadius,
       outline: 0,
       padding: variables.defaultPadding,
+      backgroundColor: variables.backgroundColor,
+      ':focus-within': {
+        borderColor: 'transparent',
+        borderBottom: variables.focusBorderBottom,
+      },
     }
   },
 
@@ -16,6 +21,10 @@ const inputRules = {
     return {
       outline: 0,
       border: 0,
+      color: variables.fontColor,
+      backgroundColor: variables.backgroundColor,
+      height: variables.height,
+      padding: variables.inputPadding,
     }
   },
 }

--- a/src/components/Input/inputRules.ts
+++ b/src/components/Input/inputRules.ts
@@ -31,6 +31,7 @@ const inputRules = {
     return {
       position: variables.iconPosition,
       right: variables.iconRight,
+      outline: 0,
     }
   },
 }

--- a/src/components/Input/inputRules.ts
+++ b/src/components/Input/inputRules.ts
@@ -5,15 +5,7 @@ const inputRules = {
       position: 'relative',
       alignItems: 'center',
       justifyContent: 'flex-end',
-      border: variables.defaultBorder,
-      borderRadius: variables.borderRadius,
       outline: 0,
-      padding: variables.defaultPadding,
-      backgroundColor: variables.backgroundColor,
-      ':focus-within': {
-        borderColor: 'transparent',
-        borderBottom: variables.focusBorderBottom,
-      },
     }
   },
 
@@ -21,10 +13,24 @@ const inputRules = {
     return {
       outline: 0,
       border: 0,
+      borderRadius: variables.borderRadius,
+      borderBottom: variables.borderBottom,
       color: variables.fontColor,
       backgroundColor: variables.backgroundColor,
       height: variables.height,
       padding: variables.inputPadding,
+
+      ':focus': {
+        borderColor: variables.inputFocusBorderColor,
+        borderRadius: variables.inputFocusBorderRadius,
+      },
+    }
+  },
+
+  icon: ({ props, variables }) => {
+    return {
+      position: variables.iconPosition,
+      right: variables.iconRight,
     }
   },
 }

--- a/src/components/Input/inputVariables.ts
+++ b/src/components/Input/inputVariables.ts
@@ -5,10 +5,18 @@ export default (siteVars: any) => {
 
   vars.borderRadius = `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`
 
-  vars.defaultBorder = `${pxToRem(1)} solid #222426`
+  vars.defaultBorder = `${pxToRem(2)} solid transparent`
   vars.defaultBorderFocus = `${pxToRem(1)} solid #85b7d9`
   vars.defaultBorderError = `${pxToRem(1)} solid #e0b4b4`
-  vars.defaultPadding = `${pxToRem(6)} 0 ${pxToRem(6)} ${pxToRem(10)}`
+  vars.defaultPadding = `${pxToRem(3)}`
+
+  vars.backgroundColor = siteVars.gray10
+  vars.fontColor = '#252424'
+  vars.fontSize = '14px'
+  vars.inputPadding = `${pxToRem(3)} ${pxToRem(6)} ${pxToRem(3)} ${pxToRem(6)}`
+  vars.focusBorderBottom = `${pxToRem(2)} solid #6264a7`
+  vars.borderBottom = `${pxToRem(2)} solid transparent`
+  vars.height = '100%'
 
   return vars
 }

--- a/src/components/Input/inputVariables.ts
+++ b/src/components/Input/inputVariables.ts
@@ -3,20 +3,20 @@ import { pxToRem } from '../../lib'
 export default (siteVars: any) => {
   const vars: any = {}
 
-  vars.borderRadius = `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`
-
-  vars.defaultBorder = `${pxToRem(2)} solid transparent`
-  vars.defaultBorderFocus = `${pxToRem(1)} solid #85b7d9`
-  vars.defaultBorderError = `${pxToRem(1)} solid #e0b4b4`
-  vars.defaultPadding = `${pxToRem(3)}`
-
-  vars.backgroundColor = siteVars.gray10
-  vars.fontColor = '#252424'
-  vars.fontSize = '14px'
-  vars.inputPadding = `${pxToRem(3)} ${pxToRem(6)} ${pxToRem(3)} ${pxToRem(6)}`
-  vars.focusBorderBottom = `${pxToRem(2)} solid #6264a7`
+  vars.borderRadius = `${pxToRem(3)}`
   vars.borderBottom = `${pxToRem(2)} solid transparent`
   vars.height = '100%'
+  vars.backgroundColor = siteVars.gray10
+
+  vars.fontColor = siteVars.fontBlack
+  vars.fontSize = siteVars.fontSizeBase
+
+  vars.inputPadding = `${pxToRem(6)} ${pxToRem(24)} ${pxToRem(6)} ${pxToRem(12)}`
+  vars.inputFocusBorderColor = siteVars.brand
+  vars.inputFocusBorderRadius = `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`
+
+  vars.iconPosition = 'absolute'
+  vars.iconRight = `${pxToRem(2)}`
 
   return vars
 }

--- a/src/themes/teams/siteVariables.ts
+++ b/src/themes/teams/siteVariables.ts
@@ -18,6 +18,7 @@ export const gray09 = '#EDEBE9'
 export const gray10 = '#F3F2F1'
 export const gray12 = blackRgbaFormat(0.05)
 export const gray14 = '#FAF9F8'
+export const fontBlack = '#252424'
 
 export const white = '#FFF'
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Input

Updating the default classes for the input to match the light view of the Teams UI.

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [x] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [x] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md

# UI Update

Simple input
![image](https://user-images.githubusercontent.com/1826985/43403791-4b6f2e5a-9416-11e8-9d24-fbf9748088b1.png)

Simple input focused
![image](https://user-images.githubusercontent.com/1826985/43466249-6517d5f4-94df-11e8-9f33-4951e7b0a2ff.png)


Input variation with icon
![image](https://user-images.githubusercontent.com/1826985/43466222-5666c272-94df-11e8-86f1-9eee77c1ce59.png)

