### PR TITLE
docs(readme): fix "Parent Child Coupling" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See the [MANIFESTO.md][1] for details. SUIR v2 will be built on the specificatio
 [105]: https://github.com/stardust-ui/react/tree/master/specifications/shorthand-api.md
 [106]: https://github.com/stardust-ui/react/tree/master/specifications/event-stack.md
 [107]: https://github.com/stardust-ui/react/tree/master/specifications/html-font-size.md
-[108]: https://github.com/stardust-ui/react/tree/master/specifications/parent-child-couplnig.md
+[108]: https://github.com/stardust-ui/react/tree/master/specifications/parent-child-coupling.md
 
 <!-- SUIR -->
 [200]: https://github.com/Semantic-Org/Semantic-UI-React


### PR DESCRIPTION
Fixed wrong link URL in README.md