### PR TITLE
fix(typings): include for each module target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+<!--------------------------------[ v0.2.5 ]------------------------------- -->
+## [v0.2.5](https://github.com/stardust-ui/react/tree/v0.2.5) (2018-08-03)
+[Compare changes](https://github.com/stardust-ui/react/compare/v0.2.4...v0.2.5)
+
+### Fixes
+- Include typings for each module target in dist @levithomason ([#48](https://github.com/stardust-ui/react/pull/48))
+
 <!--------------------------------[ v0.2.4 ]------------------------------- -->
 ## [v0.2.4](https://github.com/stardust-ui/react/tree/v0.2.4) (2018-08-03)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.2.3...v0.2.4)
@@ -32,7 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Label `icon`, `onIconClick` and `iconPosition` props @mnajdova ([#19](https://github.com/stardust-ui/react/pull/19))
 - Add Menu `vertical` prop @miroslavstastny ([#21](https://github.com/stardust-ui/react/pull/21))
 - Add Menu support for `shape="pills" vertical` @miroslavstastny ([#36](https://github.com/stardust-ui/react/pull/36))
-- Add Icon support for `background` variable @kuzhelov ([#47])((https://github.com/stardust-ui/react/pull/47))
+- Add Icon support for `background` variable @kuzhelov ([#47](https://github.com/stardust-ui/react/pull/47))
 
 ### Documentation
 - Improve UX for "knobs" form on component examples @levithomason ([#20](https://github.com/stardust-ui/react/pull/20))

--- a/build/gulp/tasks/dist.ts
+++ b/build/gulp/tasks/dist.ts
@@ -27,14 +27,17 @@ task('build:dist:commonjs', () => {
 
   const { dts, js } = src(paths.src('**/*.{ts,tsx}')).pipe(typescript())
 
-  return merge2([dts.pipe(dest(paths.dist('types'))), js.pipe(dest(paths.dist('commonjs')))])
+  return merge2([dts.pipe(dest(paths.dist('commonjs'))), js.pipe(dest(paths.dist('commonjs')))])
 })
 
 task('build:dist:es', () => {
-  const typescript = g.typescript.createProject(paths.base('build/tsconfig.es.json'))
-  return src(paths.src('**/*.{ts,tsx}'))
-    .pipe(typescript())
-    .pipe(dest(paths.dist('es')))
+  const tsConfig = paths.base('build/tsconfig.es.json')
+  const settings = { declaration: true }
+  const typescript = g.typescript.createProject(tsConfig, settings)
+
+  const { dts, js } = src(paths.src('**/*.{ts,tsx}')).pipe(typescript())
+
+  return merge2([dts.pipe(dest(paths.dist('es'))), js.pipe(dest(paths.dist('es')))])
 })
 
 task('build:dist:umd', cb => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "jsnext:main": "dist/es/index.js",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/es/index.d.ts",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
Typings cannot be found by consumers using the `es` module target.  The issue is that there is no index.d.ts in the root of the module target that points to the correct `/typings` directory.

Instead, we'll simply ship typings for each module target.

I have noted the changes under `v0.2.4` since we'll be shipping this immediately after merge.