### PR TITLE
Fixed import statement, for d.ts files

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { UIComponent, childrenExist, customPropTypes } from '../../lib'
 import buttonRules from './buttonRules'
-import buttonVariables from './buttonVariables'
+import buttonVariables, { IButtonVariables } from './buttonVariables'
 import Icon from '../Icon'
 import Text from '../Text'
 
@@ -19,7 +19,7 @@ class Button extends UIComponent<any, any> {
 
   public static rules = buttonRules
 
-  public static variables = buttonVariables
+  public static variables: (x) => IButtonVariables = buttonVariables
 
   public static propTypes = {
     /** An element type to render as (string or function). */

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import { customPropTypes, UIComponent, SUI, createShorthandFactory } from '../../lib'
 
-import iconRules from './iconRules'
-import iconVariables from './iconVariables'
+import iconRules, { IconRulesParams } from './iconRules'
+import iconVariables, { IconVariables } from './iconVariables'
 
 export type IconXSpacing = 'none' | 'before' | 'after' | 'both'
 
@@ -14,7 +14,7 @@ class Icon extends UIComponent<any, any> {
 
   static displayName = 'Icon'
 
-  static variables = iconVariables
+  static variables: (x) => IconVariables = iconVariables
 
   static propTypes = {
     /** An element type to render as (string or function). */
@@ -62,7 +62,7 @@ class Icon extends UIComponent<any, any> {
     kind: 'FontAwesome',
   }
 
-  static rules = iconRules
+  static rules: { root: (x) => IconRulesParams } = iconRules
 
   renderComponent({ ElementType, classes, rest }) {
     return <ElementType className={classes.root} {...rest} />

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -5,14 +5,14 @@ import * as React from 'react'
 import { AutoControlledComponent, childrenExist, customPropTypes } from '../../lib'
 import MenuItem from './MenuItem'
 import menuRules from './menuRules'
-import menuVariables from './menuVariables'
+import menuVariables, { IMenuVariables } from './menuVariables'
 
 class Menu extends AutoControlledComponent<any, any> {
   static displayName = 'Menu'
 
   static className = 'ui-menu'
 
-  static variables = menuVariables
+  static variables: (x) => IMenuVariables = menuVariables
 
   static create: Function
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -5,14 +5,14 @@ import * as React from 'react'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 import menuItemRules from './menuItemRules'
-import menuVariables from './menuVariables'
+import menuVariables, { IMenuVariables } from './menuVariables'
 
 class MenuItem extends UIComponent<any, any> {
   static displayName = 'MenuItem'
 
   static className = 'ui-menu__item'
 
-  static variables = menuVariables
+  static variables: (x) => IMenuVariables = menuVariables
 
   static create: Function
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import textRules from './textRules'
-import textVariables from './textVariables'
+import textVariables, { ITextVariables } from './textVariables'
 
 /**
  * A component containing text
@@ -66,7 +66,7 @@ class Text extends UIComponent<any, any> {
 
   static rules = textRules
 
-  static variables = textVariables
+  static variables: () => ITextVariables = textVariables
 
   renderComponent({ ElementType, classes, rest }): React.ReactNode {
     const { children, content } = this.props

--- a/src/components/Text/textRules.ts
+++ b/src/components/Text/textRules.ts
@@ -24,18 +24,12 @@ import {
 
 import { Sizes } from '../../lib/enums'
 import { truncateStyle } from '../../styles/customCSS'
-import { ITextVariables } from './textVariables'
-
-export interface TextRulesParams {
-  props: any
-  variables: ITextVariables
-}
 
 export default {
   root: ({
     props: { atMention, disabled, error, size, important, success, timestamp, truncated },
     variables: v,
-  }: TextRulesParams) => ({
+  }: any) => ({
     ...(truncated && truncateStyle),
     ...(atMention && { color: atMentionTextColor }),
     ...(disabled && { color: disabledTextColor }),

--- a/src/lib/debug.tsx
+++ b/src/lib/debug.tsx
@@ -9,7 +9,7 @@ if (isBrowser() && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV
   // We try/catch here as Safari throws on localStorage access in private mode or with cookies disabled.
   let DEBUG
   try {
-    DEBUG = window.localStorage.debug
+    DEBUG = (window.localStorage as any).debug
   } catch (e) {
     console.error('Semantic-UI-React could not enable debug.')
     console.error(e)

--- a/src/lib/felaRenderer.tsx
+++ b/src/lib/felaRenderer.tsx
@@ -1,4 +1,4 @@
-import { createRenderer } from 'fela'
+import { createRenderer, IRenderer } from 'fela'
 import felaPluginFallbackValue from 'fela-plugin-fallback-value'
 import felaPluginPlaceholderPrefixer from 'fela-plugin-placeholder-prefixer'
 import felaPluginPrefixer from 'fela-plugin-prefixer'
@@ -17,7 +17,7 @@ const createRendererConfig = (options: any = {}) => ({
   ...(options.isRtl ? { selectorPrefix: 'rtl_' } : {}),
 })
 
-export const felaRenderer = createRenderer(createRendererConfig())
-export const felaRtlRenderer = createRenderer(createRendererConfig({ isRtl: true }))
+export const felaRenderer: IRenderer = createRenderer(createRendererConfig())
+export const felaRtlRenderer: IRenderer = createRenderer(createRendererConfig({ isRtl: true }))
 
 export default felaRenderer


### PR DESCRIPTION
I've realized that TypeScript compiler generates wrong import paths for some of the types: rules and variables. This happens because we use implicit import for static properties and compiler inlines import statements.
To avoid this, we have to explicitly specify the type of the rules and/or variables or remove typing for such properties, if it is more appropriate.