### PR TITLE
feat(Menu): Accessibility - move MenuItem onClick handler from li to a

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -86,17 +86,13 @@ class MenuItem extends UIComponent<any, any> {
     const { children, content } = this.props
 
     return (
-      <ElementType
-        className={classes.root}
-        onClick={this.handleClick}
-        {...accessibility.attributes.root}
-        {...rest}
-      >
+      <ElementType className={classes.root} {...accessibility.attributes.root} {...rest}>
         {childrenExist(children) ? (
           children
         ) : (
           <a
             className={cx('ui-menu__item__anchor', classes.anchor)}
+            onClick={this.handleClick}
             {...accessibility.attributes.anchor}
           >
             {content}

--- a/src/components/Menu/menuItemRules.ts
+++ b/src/components/Menu/menuItemRules.ts
@@ -37,8 +37,6 @@ export default {
       lineHeight: 1,
       position: 'relative',
       verticalAlign: 'middle',
-      padding: `${pxToRem(14)} ${pxToRem(18)}`,
-      cursor: 'pointer',
       display: 'block',
       ...(shape === 'pills' && {
         ...(vertical ? { margin: `0 0 ${pxToRem(5)} 0` } : { margin: `0 ${pxToRem(8)} 0 0` }),
@@ -63,12 +61,6 @@ export default {
           background: variables.defaultActiveBackgroundColor,
           ...(type === 'primary' && {
             background: variables.typePrimaryActiveBackgroundColor,
-          }),
-        }),
-        ...(shape === 'underlined' && {
-          ...underlinedItem(variables.defaultActiveBackgroundColor),
-          ...(type === 'primary' && {
-            ...underlinedItem(variables.typePrimaryActiveBorderColor),
           }),
         }),
       },
@@ -114,8 +106,37 @@ export default {
             }),
           },
         }),
+      }),
+    }
+  },
+
+  anchor: ({ props, variables }) => {
+    const { active, shape, type } = props
+
+    return {
+      color: 'inherit',
+      display: 'block',
+      ...(shape === 'underlined'
+        ? { padding: '0 0 8px 0' }
+        : { padding: `${pxToRem(14)} ${pxToRem(18)}` }),
+      cursor: 'pointer',
+
+      ':hover': {
+        color: 'inherit',
         ...(shape === 'underlined' && {
+          paddingBottom: '4px',
+          ...underlinedItem(variables.defaultActiveBackgroundColor),
+          ...(type === 'primary' && {
+            ...underlinedItem(variables.typePrimaryActiveBorderColor),
+          }),
+        }),
+      },
+
+      ...(active &&
+        shape === 'underlined' && {
           color: variables.defaultColor,
+          paddingBottom: '4px',
+          ':hover': {},
           ...underlinedItem(variables.defaultActiveColor),
           ...(type === 'primary'
             ? {
@@ -126,13 +147,6 @@ export default {
                 fontWeight: '700',
               }),
         }),
-      }),
     }
   },
-  anchor: () => ({
-    color: 'inherit',
-    ':hover': {
-      color: 'inherit',
-    },
-  }),
 }

--- a/test/specs/components/Menu/Menu-test.tsx
+++ b/test/specs/components/Menu/Menu-test.tsx
@@ -27,7 +27,11 @@ describe('Menu', () => {
       const items = getItems()
       const menuItems = mountWithProvider(<Menu items={items} />).find('MenuItem')
 
-      menuItems.first().simulate('click')
+      menuItems
+        .first()
+        .find('a')
+        .first()
+        .simulate('click')
       expect(items[0].onClick).toHaveBeenCalled()
     })
 
@@ -48,7 +52,11 @@ describe('Menu', () => {
         const wrapper = mountWithProvider(<Menu items={getItems()} />)
         const menuItems = wrapper.find('MenuItem')
 
-        menuItems.at(1).simulate('click')
+        menuItems
+          .at(1)
+          .find('a')
+          .first()
+          .simulate('click')
 
         const updatedItems = wrapper.find('MenuItem')
 


### PR DESCRIPTION
# MenuItem

Move onClick handler from `<li>` to `<a>` for the menu to be accessible.

See issue: https://github.com/stardust-ui/react/issues/44

Currently Conformance test is failing in **handle events transparently**:
```
Error: Handler for 'onClick' is not passed to child event emitter element <li />
```

### TODO

- [ ] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md
