### PR TITLE
chore: introduce mergeThemes function

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as _ from 'lodash'
 
 import {
+  callable,
   childrenExist,
   createHTMLInput,
   customPropTypes,
@@ -13,7 +14,6 @@ import {
 import inputStyles from '../../themes/teams/components/Input/inputStyles'
 import inputVariables from '../../themes/teams/components/Input/inputVariables'
 import Icon from '../Icon'
-import callable from '../../lib/callable'
 
 /**
  * An Input

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,12 +2,17 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
 
-import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
+import {
+  callable,
+  childrenExist,
+  createShorthandFactory,
+  customPropTypes,
+  UIComponent,
+} from '../../lib'
 
 import { Icon } from '../..'
 import labelStyles from '../../themes/teams/components/Label/labelStyles'
 import labelVariables from '../../themes/teams/components/Label/labelVariables'
-import callable from '../../lib/callable'
 
 /**
  * A label displays content classification

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,9 +9,11 @@ export { default as eventStack } from './eventStack'
 export { felaRenderer, felaRtlRenderer } from './felaRenderer'
 
 export * from './factories'
+export { default as callable } from './callable'
 export { default as getClasses } from './getClasses'
 export { default as getElementType } from './getElementType'
 export { default as getUnhandledProps } from './getUnhandledProps'
+export { default as mergeThemes } from './mergeThemes'
 export { default as renderComponent, IRenderResultConfig } from './renderComponent'
 export {
   useKeyOnly,

--- a/src/lib/mergeThemes.ts
+++ b/src/lib/mergeThemes.ts
@@ -1,0 +1,125 @@
+import * as _ from 'lodash'
+import {
+  ISiteVariables,
+  IThemeComponentStylesInput,
+  IThemeComponentStylesPrepared,
+  IThemeComponentVariablesInput,
+  IThemeComponentVariablesPrepared,
+  IThemeInput,
+  IThemePrepared,
+} from '../../types/theme'
+import callable from './callable'
+import { felaRenderer, felaRtlRenderer } from './felaRenderer'
+
+/**
+ * Site variables can safely be merged at each Provider in the tree.
+ * They are flat objects and do not depend on render-time values, such as props.
+ */
+const mergeSiteVariables = (
+  target: ISiteVariables,
+  ...sources: ISiteVariables[],
+): ISiteVariables => {
+  return sources.reduce((acc, next) => ({ ...acc, ...next }), target)
+}
+
+/**
+ * Component variables can be objects, functions, or an array of these.
+ * The functions must be called with the final result of siteVariables, otherwise
+ *   the component variable objects would have no ability to apply siteVariables.
+ * Therefore, componentVariables must be resolved by the component at render time.
+ * We instead pass down call stack of component variable functions to be resolved later.
+ */
+const mergeComponentVariables = (
+  target: IThemeComponentVariablesInput,
+  ...sources: IThemeComponentVariablesInput[],
+): IThemeComponentVariablesPrepared => {
+  const displayNames = _.union(_.keys(target), ..._.map(sources, _.keys))
+
+  return sources.reduce((acc, next) => {
+    return displayNames.reduce((componentVariables, displayName) => {
+      // Break references to avoid an infinite loop.
+      // We are replacing functions with new ones that calls the originals.
+      const originalTarget = acc[displayName]
+      const originalSource = next[displayName]
+
+      componentVariables[displayName] = siteVariables => {
+        return {
+          ...callable(originalTarget)(siteVariables),
+          ...callable(originalSource)(siteVariables),
+        }
+      }
+
+      return componentVariables
+    }, {})
+  }, target)
+}
+
+/**
+ * See mergeComponentVariables() description.
+ * Component styles adhere to the same pattern as component variables, except
+ *   that they return style objects.
+ */
+const mergeComponentStyles = (
+  target: IThemeComponentStylesInput,
+  ...sources: IThemeComponentStylesInput[],
+): IThemeComponentStylesPrepared => {
+  const initial: IThemeComponentStylesPrepared = _.mapValues(target, stylesByPart => {
+    return _.mapValues(stylesByPart, callable)
+  })
+
+  return sources.reduce<IThemeComponentStylesPrepared>((acc, next) => {
+    _.forEach(next, (stylesByPart, displayName) => {
+      acc[displayName] = acc[displayName] || {}
+
+      _.forEach(stylesByPart, (partStyle, partName) => {
+        // Break references to avoid an infinite loop.
+        // We are replacing functions with a new ones that calls the originals.
+        const originalTarget = acc[displayName][partName]
+        const originalSource = next[displayName][partName]
+
+        acc[displayName][partName] = styleParam => {
+          return _.merge(callable(originalTarget)(styleParam), callable(originalSource)(styleParam))
+        }
+      })
+    })
+
+    return acc
+  }, initial)
+}
+
+const mergeRTL = (target, ...sources) => {
+  return !!sources.reduce((acc, next) => {
+    return typeof next === 'boolean' ? next : acc
+  }, target)
+}
+
+const mergeThemes = (...themes: IThemeInput[]): IThemePrepared => {
+  const emptyTheme = {
+    siteVariables: {},
+    componentVariables: {},
+    componentStyles: {},
+  } as IThemePrepared
+
+  return themes.reduce<IThemePrepared>((acc: IThemePrepared, next: IThemeInput) => {
+    if (!next) return acc
+
+    acc.siteVariables = mergeSiteVariables(acc.siteVariables, next.siteVariables)
+
+    acc.componentVariables = mergeComponentVariables(
+      acc.componentVariables,
+      next.componentVariables,
+    )
+
+    acc.componentStyles = mergeComponentStyles(acc.componentStyles, next.componentStyles)
+
+    // Latest RTL value wins
+    acc.rtl = mergeRTL(acc.rtl, next.rtl)
+
+    // Use the correct renderer for RTL
+    acc.renderer = acc.rtl ? felaRtlRenderer : felaRenderer
+
+    return acc
+  }, emptyTheme)
+}
+
+export default mergeThemes

--- a/src/lib/mergeThemes.ts
+++ b/src/lib/mergeThemes.ts
@@ -17,7 +17,7 @@ import { felaRenderer, felaRtlRenderer } from './felaRenderer'
  */
 const mergeSiteVariables = (
   target: ISiteVariables,
-  ...sources: ISiteVariables[],
+  ...sources: ISiteVariables[]
 ): ISiteVariables => {
   return sources.reduce((acc, next) => ({ ...acc, ...next }), target)
 }
@@ -31,7 +31,7 @@ const mergeSiteVariables = (
  */
 const mergeComponentVariables = (
   target: IThemeComponentVariablesInput,
-  ...sources: IThemeComponentVariablesInput[],
+  ...sources: IThemeComponentVariablesInput[]
 ): IThemeComponentVariablesPrepared => {
   const displayNames = _.union(_.keys(target), ..._.map(sources, _.keys))
 
@@ -61,7 +61,7 @@ const mergeComponentVariables = (
  */
 const mergeComponentStyles = (
   target: IThemeComponentStylesInput,
-  ...sources: IThemeComponentStylesInput[],
+  ...sources: IThemeComponentStylesInput[]
 ): IThemeComponentStylesPrepared => {
   const initial: IThemeComponentStylesPrepared = _.mapValues(target, stylesByPart => {
     return _.mapValues(stylesByPart, callable)

--- a/test/specs/lib/mergeThemes-test.ts
+++ b/test/specs/lib/mergeThemes-test.ts
@@ -1,0 +1,237 @@
+import mergeThemes from '../../../src/lib/mergeThemes'
+import { felaRtlRenderer, felaRenderer } from '../../../src/lib'
+
+describe('mergeThemes', () => {
+  test('gracefully handles undefined themes', () => {
+    expect(() => mergeThemes(undefined, undefined)).not.toThrow()
+  })
+
+  describe('siteVariables', () => {
+    test('merges top level keys', () => {
+      const target = { siteVariables: { overridden: false, keep: true } }
+      const source = { siteVariables: { overridden: true, add: true } }
+
+      expect(mergeThemes(target, source)).toMatchObject({
+        siteVariables: { overridden: true, keep: true, add: true },
+      })
+    })
+
+    test('disregards nested keys', () => {
+      const target = { siteVariables: { nested: { replaced: true } } }
+      const source = { siteVariables: { nested: { other: 'value' } } }
+
+      expect(mergeThemes(target, source)).toMatchObject({
+        siteVariables: { nested: { other: 'value' } },
+      })
+    })
+  })
+
+  describe('componentVariables', () => {
+    test('component names are merged', () => {
+      const target = { componentVariables: { Button: {} } }
+      const source = { componentVariables: { Icon: {} } }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentVariables).toHaveProperty('Button')
+      expect(merged.componentVariables).toHaveProperty('Icon')
+    })
+
+    test('objects are converted to functions', () => {
+      const target = { componentVariables: { Button: { color: 'red' } } }
+      const source = { componentVariables: { Icon: { color: 'blue' } } }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentVariables.Button).toBeInstanceOf(Function)
+      expect(merged.componentVariables.Icon).toBeInstanceOf(Function)
+    })
+
+    test('functions return merged variables', () => {
+      const target = { componentVariables: { Button: () => ({ one: 1, three: 3 }) } }
+      const source = {
+        componentVariables: { Button: () => ({ one: 'one', two: 'two' }) },
+      }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentVariables.Button()).toMatchObject({
+        one: 'one',
+        two: 'two',
+        three: 3,
+      })
+    })
+
+    test('functions accept and apply siteVariables', () => {
+      const target = {
+        componentVariables: {
+          Button: siteVariables => ({ one: 1, target: true, ...siteVariables }),
+        },
+      }
+
+      const source = {
+        componentVariables: {
+          Button: siteVariables => ({ two: 2, source: true, ...siteVariables }),
+        },
+      }
+
+      const merged = mergeThemes(target, source)
+
+      const siteVariables = { one: 'one', two: 'two' }
+
+      expect(merged.componentVariables.Button(siteVariables)).toMatchObject({
+        one: 'one',
+        two: 'two',
+        source: true,
+        target: true,
+      })
+    })
+  })
+
+  describe('componentStyles', () => {
+    test('component names are merged', () => {
+      const target = { componentStyles: { Button: {} } }
+      const source = { componentStyles: { Icon: {} } }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentStyles).toHaveProperty('Button')
+      expect(merged.componentStyles).toHaveProperty('Icon')
+    })
+
+    test('component parts are merged', () => {
+      const target = { componentStyles: { Button: { root: {} } } }
+      const source = { componentStyles: { Button: { icon: {} } } }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentStyles.Button).toHaveProperty('root')
+      expect(merged.componentStyles.Button).toHaveProperty('icon')
+    })
+
+    test('component part objects are converted to functions', () => {
+      const target = { componentStyles: { Button: { root: {} } } }
+      const source = { componentStyles: { Icon: { root: {} } } }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentStyles.Button.root).toBeInstanceOf(Function)
+      expect(merged.componentStyles.Icon.root).toBeInstanceOf(Function)
+    })
+
+    test('component part styles are deeply merged', () => {
+      const target = {
+        componentStyles: {
+          Button: {
+            root: {
+              display: 'inline-block',
+              color: 'green',
+              '::before': {
+                content: 'before content',
+              },
+            },
+          },
+        },
+      }
+
+      const source = {
+        componentStyles: {
+          Button: {
+            root: {
+              color: 'blue',
+              '::before': {
+                color: 'red',
+              },
+            },
+          },
+        },
+      }
+
+      const merged = mergeThemes(target, source)
+
+      expect(merged.componentStyles.Button.root()).toMatchObject({
+        display: 'inline-block',
+        color: 'blue',
+        '::before': {
+          content: 'before content',
+          color: 'red',
+        },
+      })
+    })
+
+    test('functions can accept and apply params', () => {
+      const target = {
+        componentStyles: {
+          Button: {
+            root: param => ({ target: true, ...param }),
+          },
+        },
+      }
+
+      const source = {
+        componentStyles: {
+          Button: {
+            root: param => ({ source: true, ...param }),
+          },
+        },
+      }
+
+      const merged = mergeThemes(target, source)
+
+      const styleParam = {
+        siteVariables: { brand: '#38E' },
+        variables: { iconSize: 'large' },
+        props: { primary: true },
+        rtl: false,
+      }
+
+      expect(merged.componentStyles.Button.root(styleParam)).toMatchObject({
+        source: true,
+        target: true,
+        ...styleParam,
+      })
+    })
+  })
+
+  describe('rtl', () => {
+    test('latest boolean value wins', () => {
+      expect(mergeThemes({ rtl: false }, { rtl: true })).toHaveProperty('rtl', true)
+      expect(mergeThemes({ rtl: true }, { rtl: false })).toHaveProperty('rtl', false)
+
+      expect(mergeThemes({ rtl: null }, { rtl: true })).toHaveProperty('rtl', true)
+      expect(mergeThemes({ rtl: null }, { rtl: false })).toHaveProperty('rtl', false)
+
+      expect(mergeThemes({ rtl: undefined }, { rtl: true })).toHaveProperty('rtl', true)
+      expect(mergeThemes({ rtl: undefined }, { rtl: false })).toHaveProperty('rtl', false)
+    })
+
+    test('null values do not override boolean values', () => {
+      expect(mergeThemes({ rtl: false }, { rtl: null })).toHaveProperty('rtl', false)
+      expect(mergeThemes({ rtl: true }, { rtl: null })).toHaveProperty('rtl', true)
+    })
+
+    test('undefined values do not override boolean values', () => {
+      expect(mergeThemes({ rtl: false }, { rtl: undefined })).toHaveProperty('rtl', false)
+      expect(mergeThemes({ rtl: true }, { rtl: undefined })).toHaveProperty('rtl', true)
+    })
+
+    test('default to false if no boolean was provided', () => {
+      expect(mergeThemes({ rtl: null }, { rtl: null })).toHaveProperty('rtl', false)
+      expect(mergeThemes({ rtl: null }, { rtl: undefined })).toHaveProperty('rtl', false)
+
+      expect(mergeThemes({ rtl: undefined }, { rtl: null })).toHaveProperty('rtl', false)
+      expect(mergeThemes({ rtl: undefined }, { rtl: undefined })).toHaveProperty('rtl', false)
+    })
+  })
+
+  describe('renderer', () => {
+    test('felaRtlRenderer is chosen if rtl is true', () => {
+      expect(mergeThemes({ rtl: true })).toHaveProperty('renderer', felaRtlRenderer)
+    })
+    test('felaRenderer is chosen if rtl is not true', () => {
+      expect(mergeThemes({ rtl: false })).toHaveProperty('renderer', felaRenderer)
+      expect(mergeThemes({ rtl: null })).toHaveProperty('renderer', felaRenderer)
+      expect(mergeThemes({ rtl: undefined })).toHaveProperty('renderer', felaRenderer)
+    })
+  })
+})

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,16 @@
     "ter-arrow-parens": [false],
     "ter-computed-property-spacing": [false],
     "ter-indent": [false],
+    "trailing-comma": [true, {
+        "multiline": {
+          "objects": "always",
+          "arrays": "always",
+          "functions": "always",
+          "typeLiterals": "ignore"
+        },
+        "esSpecCompliant": true
+      }
+    ],
     "variable-name": false
   }
 }

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -1,0 +1,188 @@
+import * as CSSType from 'csstype'
+import { IRenderer as IFelaRenderer } from 'fela'
+import * as React from 'react'
+
+// Themes go through 3 phases.
+// 1. Input - (from the user), variable and style objects/functions, some values optional
+// 2. Prepared - (on context), variable and style functions only, all values required
+// 3. Resolved - (for rendering), plain object variables and styles, all values required
+//
+// We use these terms in typings to indicate which phase the typings apply to.
+
+// ========================================================
+// Utilities
+// ========================================================
+
+type ObjectOf<T> = { [key: string]: T }
+
+// ========================================================
+// Props
+// ========================================================
+
+export type IProps = ObjectOf<any>
+
+// ========================================================
+// Variables
+// ========================================================
+
+export interface ISiteVariables {
+  [key: string]: any
+
+  brand?: string
+  htmlFontSize?: string
+}
+
+export type ComponentVariableValue = string | number | boolean
+
+export type ComponentVariablesObject = ObjectOf<ComponentVariableValue>
+
+export type ComponentVariablesFunction = (
+  siteVariables?: ISiteVariables,
+) => ComponentVariablesObject
+
+export type ComponentVariablesInput = ComponentVariablesObject | ComponentVariablesFunction
+
+// ========================================================
+// Styles
+// ========================================================
+
+export interface ICSSPseudoElementStyle extends ICSSInJSStyle {
+  content?: string
+}
+
+export interface ICSSInJSStyle extends React.CSSProperties {
+  // missing React.CSSProperties
+  speak?: CSSType.Globals | 'none' | 'normal' | 'spell-out'
+
+  // CSS in JS Properties
+  '::before'?: ICSSPseudoElementStyle
+  '::after'?: ICSSPseudoElementStyle
+
+  ':hover'?: ICSSInJSStyle
+  ':active'?: ICSSInJSStyle
+  ':focus'?: ICSSInJSStyle
+  ':visited'?: ICSSInJSStyle
+}
+
+export interface ComponentStyleFunctionParam {
+  props: IProps
+  variables: ComponentVariablesObject
+  rtl: boolean
+}
+
+export type ComponentPartStyleFunction = (styleParam?: ComponentStyleFunctionParam) => ICSSInJSStyle
+
+export type ComponentPartStyle = ComponentPartStyleFunction | ICSSInJSStyle
+
+export interface IComponentPartStylesInput {
+  [part: string]: ComponentPartStyle
+
+  root?: ComponentPartStyle
+}
+
+export interface IComponentPartStylesPrepared {
+  [part: string]: ComponentPartStyleFunction
+
+  root?: ComponentPartStyleFunction
+}
+
+// ========================================================
+// Theme
+// ========================================================
+export interface IThemeInput {
+  siteVariables?: ISiteVariables
+  componentVariables?: IThemeComponentVariablesInput
+  componentStyles?: IThemeComponentStylesInput
+  rtl?: boolean
+  renderer?: IRenderer
+}
+
+// Component variables and styles must be resolved by the component after
+// all cascading is complete, not by any Provider in the middle of the tree.
+// This ensures the final site variables are used in the component's variables
+// and styles. Resolving component variables/styles in the Provider would mean
+// the latest site variables might not be applied to the component.
+//
+// As a theme cascades down the tree and is merged with the previous theme on
+// context, the resulting theme takes this shape.
+export interface IThemePrepared {
+  siteVariables: ISiteVariables
+  componentVariables: {
+    [key in keyof IThemeComponentVariablesPrepared]: ComponentVariablesFunction
+  }
+  componentStyles: { [key in keyof IThemeComponentStylesPrepared]: IComponentPartStylesPrepared }
+  rtl: boolean
+  renderer: IRenderer
+}
+
+export interface IThemeComponentStylesInput {
+  Accordion?: IComponentPartStylesInput
+  Avatar?: IComponentPartStylesInput
+  Button?: IComponentPartStylesInput
+  Chat?: IComponentPartStylesInput
+  Divider?: IComponentPartStylesInput
+  Header?: IComponentPartStylesInput
+  Icon?: IComponentPartStylesInput
+  Image?: IComponentPartStylesInput
+  Input?: IComponentPartStylesInput
+  Label?: IComponentPartStylesInput
+  Layout?: IComponentPartStylesInput
+  List?: IComponentPartStylesInput
+  ListItem?: IComponentPartStylesInput
+  Menu?: IComponentPartStylesInput
+  Text?: IComponentPartStylesInput
+}
+
+export interface IThemeComponentStylesPrepared {
+  Accordion?: IComponentPartStylesPrepared
+  Avatar?: IComponentPartStylesPrepared
+  Button?: IComponentPartStylesPrepared
+  Chat?: IComponentPartStylesPrepared
+  Divider?: IComponentPartStylesPrepared
+  Header?: IComponentPartStylesPrepared
+  Icon?: IComponentPartStylesPrepared
+  Image?: IComponentPartStylesPrepared
+  Input?: IComponentPartStylesPrepared
+  Label?: IComponentPartStylesPrepared
+  Layout?: IComponentPartStylesPrepared
+  List?: IComponentPartStylesPrepared
+  ListItem?: IComponentPartStylesPrepared
+  Menu?: IComponentPartStylesPrepared
+  Text?: IComponentPartStylesPrepared
+}
+
+export interface IThemeComponentVariablesInput {
+  Accordion?: ComponentVariablesInput
+  Avatar?: ComponentVariablesInput
+  Button?: ComponentVariablesInput
+  Chat?: ComponentVariablesInput
+  Divider?: ComponentVariablesInput
+  Header?: ComponentVariablesInput
+  Icon?: ComponentVariablesInput
+  Image?: ComponentVariablesInput
+  Input?: ComponentVariablesInput
+  Label?: ComponentVariablesInput
+  Layout?: ComponentVariablesInput
+  ListItem?: ComponentVariablesInput
+  Menu?: ComponentVariablesInput
+  Text?: ComponentVariablesInput
+}
+
+export interface IThemeComponentVariablesPrepared {
+  Accordion?: ComponentVariablesFunction
+  Avatar?: ComponentVariablesFunction
+  Button?: ComponentVariablesFunction
+  Chat?: ComponentVariablesFunction
+  Divider?: ComponentVariablesFunction
+  Header?: ComponentVariablesFunction
+  Icon?: ComponentVariablesFunction
+  Image?: ComponentVariablesFunction
+  Input?: ComponentVariablesFunction
+  Label?: ComponentVariablesFunction
+  Layout?: ComponentVariablesFunction
+  ListItem?: ComponentVariablesFunction
+  Menu?: ComponentVariablesFunction
+  Text?: ComponentVariablesFunction
+}
+
+export interface IRenderer extends IFelaRenderer {}


### PR DESCRIPTION
This is another breakout of #16.

👉 The best way to review the features is to review `mergeThemes-test.ts`.  This gives 100% coverage of all the functionality introduced to what will be the public API.

***

This PR introduces the `mergeThemes` function.  This function is not used anywhere currently.  It is introduced separately here to introduce the typings, tests, and patterns we'll use for merging themes in nested Providers.

The next phase will be implementing theme merging in nested Providers.

