### PR TITLE
feat(Header): introduce 'color' variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add selection property to child items in ListExampleSelection so that styles and roles are applied properly @jurokapsiar ([#70](https://github.com/stardust-ui/react/pull/70))
 
+### Features
+- Add `color` variables to Header and Header.Description @kuzhelov ([#72](https://github.com/stardust-ui/react/pull/72))
+
 <!--------------------------------[ v0.2.6 ]------------------------------- -->
 ## [v0.2.6](https://github.com/stardust-ui/react/tree/v0.2.6) (2018-08-09)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.2.5...v0.2.6)

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import HeaderDescription from './HeaderDescription'
 import headerStyles from '../../themes/teams/components/Header/headerStyles'
+import headerVariables from './headerVariables'
 
 /**
  * A header provides a short summary of content
@@ -34,15 +35,28 @@ class Header extends UIComponent<any, any> {
 
     /** Align header content. */
     textAlign: PropTypes.oneOf(['left', 'center', 'right', 'justified']),
+
+    /** Custom values for styling variables. */
+    variables: PropTypes.object,
   }
 
   static defaultProps = {
     as: 'h1',
   }
 
-  static handledProps = ['as', 'children', 'className', 'content', 'description', 'textAlign']
+  static handledProps = [
+    'as',
+    'children',
+    'className',
+    'content',
+    'description',
+    'textAlign',
+    'variables',
+  ]
 
   static styles = headerStyles
+
+  static variables = headerVariables
 
   static Description = HeaderDescription
 

--- a/src/components/Header/HeaderDescription.tsx
+++ b/src/components/Header/HeaderDescription.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 
 import headerDescriptionStyles from '../../themes/teams/components/Header/headerDescriptionStyles'
+import headerDescriptionVariables from './headerDescriptionVariables'
 
 /**
  * Headers may contain description.
@@ -27,15 +28,20 @@ class HeaderDescription extends UIComponent<any, any> {
 
     /** Shorthand for primary content. */
     content: customPropTypes.contentShorthand,
+
+    /** Custom values for styling variables. */
+    variables: PropTypes.object,
   }
 
   static defaultProps = {
     as: 'p',
   }
 
-  static handledProps = ['as', 'children', 'className', 'content']
+  static handledProps = ['as', 'children', 'className', 'content', 'variables']
 
   static styles = headerDescriptionStyles
+
+  static variables = headerDescriptionVariables
 
   renderComponent({ ElementType, classes, rest }) {
     const { children, content } = this.props

--- a/src/components/Header/headerDescriptionVariables.ts
+++ b/src/components/Header/headerDescriptionVariables.ts
@@ -1,0 +1,3 @@
+export default siteVariables => ({
+  color: 'rgba(0,0,0,.6)',
+})

--- a/src/components/Header/headerVariables.ts
+++ b/src/components/Header/headerVariables.ts
@@ -1,0 +1,3 @@
+export default siteVariables => ({
+  color: 'black',
+})

--- a/src/themes/teams/components/Header/headerDescriptionStyles.ts
+++ b/src/themes/teams/components/Header/headerDescriptionStyles.ts
@@ -1,10 +1,10 @@
 import { pxToRem } from '../../../../lib'
 
 export default {
-  root: () => ({
+  root: ({ variables: v }) => ({
     display: 'block',
     fontSize: pxToRem(22),
-    color: 'rgba(0,0,0,.6)',
+    color: v.color,
     fontWeight: 400,
   }),
 }

--- a/src/themes/teams/components/Header/headerStyles.ts
+++ b/src/themes/teams/components/Header/headerStyles.ts
@@ -1,5 +1,6 @@
 export default {
-  root: ({ props }) => ({
+  root: ({ props, variables: v }) => ({
+    color: v.color,
     textAlign: props.textAlign,
     display: 'block',
     ...(props.description && { marginBottom: 0 }),


### PR DESCRIPTION
# Header color

Introduce `color` property to `Header` and `Header.Description`

### TODO

- [x] Conformance test
- [ ] Minimal doc site example
- [x] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [x] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md

# API Proposal

## Header - color (variable)

Defines color of `Header`.

![image](https://user-images.githubusercontent.com/9024564/43900739-fcb719b2-9be5-11e8-89d5-8973b3278eeb.png)

```jsx
<Header variables={{ color: 'red' }} content="..." />
```
-----------------

## Header.Description - color (variable)

Defines color of header's description (Header.Description).

![image](https://user-images.githubusercontent.com/9024564/43900876-54fa4018-9be6-11e8-8904-2ab38b7997e8.png)

```jsx
<Header ... >
   <Header.Description variables={{ color: 'red' }} content='...' />
</Header>
```