### PR TITLE
fix(Provider): temporarily disable consumer typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Menu `onClick` handler moved from `li` to `a` (accessibility) @miroslavstastny ([#61](https://github.com/stardust-ui/react/pull/61))
 - Image `fluid` is applied on the avatar variations @mnajdova ([#77](https://github.com/stardust-ui/react/pull/77))
 - Include missing `types` directory in dist @smykhailov ([#76](https://github.com/stardust-ui/react/pull/76))
+- Temporarily disable Provider.Consumer typings to avoid TS bug @levithomason ([#88](https://github.com/stardust-ui/react/pull/88))
 
 ### Features
 - Add `color` variables to Header and Header.Description @kuzhelov ([#72](https://github.com/stardust-ui/react/pull/72))

--- a/src/components/Provider/ProviderConsumer.tsx
+++ b/src/components/Provider/ProviderConsumer.tsx
@@ -2,16 +2,20 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import { FelaTheme } from 'react-fela'
 
-import { IThemePrepared } from '../../../types/theme'
-
-export interface IProviderConsumerProps {
-  render: (theme: IThemePrepared) => React.ReactNode
-}
+// TODO: TypeScript incorrectly compiles typings defined in component files
+// TODO: see: https://github.com/stardust-ui/react/issues/87#issuecomment-412657622
+//
+// import { IThemePrepared } from '../../../types/theme'
+//
+// export interface IProviderConsumerProps {
+//   render: (theme: IThemePrepared) => React.ReactNode
+// }
 
 /**
  * The Provider's Consumer is for accessing the theme.
  */
-const ProviderConsumer: React.SFC<IProviderConsumerProps> = props => <FelaTheme {...props} />
+// TODO: restore provider consumer interface once above bug is fixed
+const ProviderConsumer: React.SFC<any> = props => <FelaTheme {...props} />
 
 ProviderConsumer.propTypes = {
   /**


### PR DESCRIPTION
This PR introduces a temporary workaround to #87.  

### Workaround

This branch temporarily removes the Consumer's typings which also sidesteps the bug for now.  There is a TODO linked to the GitHub issue for later resolution.

### Proper Fix

In https://github.com/stardust-ui/react/pull/89, we're adding a proper project build test that will consume the dist directory and ensure the project will compile.