### PR TITLE
fix: build failure on windows machine

### DIFF
--- a/build/gulp/sh.ts
+++ b/build/gulp/sh.ts
@@ -1,28 +1,13 @@
-import { spawn } from 'child_process'
+import { exec } from 'child_process'
 
-const sh = (command, cb) => {
-  const [cmd, ...args] = command.split(' ')
-
+const sh = (cmd, cb) => {
   const options = {
     cwd: process.cwd(),
     env: process.env,
+    stdio: 'inherit',
   }
 
-  const child = spawn(cmd, args, options)
-
-  child.stdout.on('data', data => {
-    console.log(data.toString())
-  })
-
-  child.stderr.on('data', data => {
-    console.error(data.toString())
-  })
-
-  child.on('close', code => {
-    if (code === 0) return cb()
-
-    cb(new Error(`child process exited with code ${code}`))
-  })
+  exec(cmd, options, cb)
 }
 
 export default sh

--- a/build/gulp/tasks/docs.ts
+++ b/build/gulp/tasks/docs.ts
@@ -90,11 +90,7 @@ task('build:docs:images', () =>
 task('build:docs:toc', () =>
   src(markdownSrc, { since: lastRun('build:docs:toc') }).pipe(
     through2.obj((file, enc, done) => {
-      sh(`doctoc ${file.path} --github --maxlevel 4`, err => {
-        if (err) return done(err)
-
-        sh(`git add ${file.path}`, done)
-      })
+      sh(`doctoc ${file.path} --github --maxlevel 4 && git add ${file.path}`, done)
     }),
   ),
 )


### PR DESCRIPTION
# Fix

## Before 
The build on windows machine was failing with the following error:
```
[10:46:09] 'build:docs:toc' errored after 538 ms
[10:46:09] Error: spawn doctoc ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
[10:46:09] 'build:docs' errored after 785 ms
[10:46:09] 'docs' errored after 864 ms
[10:46:09] The following tasks did not complete: <series>, clean:docs, clean:docs:dist
[10:46:09] Did you forget to signal async completion?
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: C:\\WINDOWS\\system32\\cmd.exe
Arguments: /d /s /c gulp --series dll docs
Directory: C:\\workspace\\stardust-react\\react
Output:
".
info If you think this is a bug, please open a bug report with the information provided in "C:\\workspace\\stardust-react\\react\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## After
The build is successful.

## Solution
The fix was reverting the changes in the docs.ts and sh.ts files from the https://github.com/stardust-ui/react/pull/80 

