### PR TITLE
fix(build): on windows machines

### DIFF
--- a/build/gulp/sh.ts
+++ b/build/gulp/sh.ts
@@ -6,17 +6,11 @@ const sh = (command, cb) => {
   const options = {
     cwd: process.cwd(),
     env: process.env,
+    stdio: 'inherit',
+    shell: true,
   }
 
   const child = spawn(cmd, args, options)
-
-  child.stdout.on('data', data => {
-    console.log(data.toString())
-  })
-
-  child.stderr.on('data', data => {
-    console.error(data.toString())
-  })
 
   child.on('close', code => {
     if (code === 0) return cb()


### PR DESCRIPTION
Fix Windows build issue (#90):

```
[10:46:09] 'build:docs:toc' errored after 538 ms
[10:46:09] Error: spawn doctoc ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
[10:46:09] 'build:docs' errored after 785 ms
[10:46:09] 'docs' errored after 864 ms
[10:46:09] The following tasks did not complete: <series>, clean:docs, clean:docs:dist
[10:46:09] Did you forget to signal async completion?
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: C:\\WINDOWS\\system32\\cmd.exe
Arguments: /d /s /c gulp --series dll docs
Directory: C:\\workspace\\stardust-react\\react
Output:
".
info If you think this is a bug, please open a bug report with the information provided in "C:\\workspace\\stardust-react\\react\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This one was caused by the fact that 'doctoc' utility wasn't found while executing build stage. The problem was fixed by introducing 'shell' option to Node's 'spawn' function - this ensures that context of executing shell is preserved on spawning (in our case it is about preserving context of npm script - this one allows to resolve utilities from project's bin directory of node_modules).